### PR TITLE
fix(endpoints): correct the example endpoint

### DIFF
--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -61,7 +61,7 @@ name | required | description
 ### Test
 
 ```shell
-curl -X GET https://api.counterapi.dev/v1/test/test/?count=10
+curl -X GET https://api.counterapi.dev/v1/test/test/set?count=10
 ```
 
 <APIRun type="set" />


### PR DESCRIPTION
The example endpoint doesn't include the path `/set`. The counter can be set only if the `count` param is passed on the `/set` path.